### PR TITLE
Remove 'server-only' from unneeded files

### DIFF
--- a/lib/columns.helpers.ts
+++ b/lib/columns.helpers.ts
@@ -1,4 +1,3 @@
-import 'server-only';
 import { timestamp } from 'drizzle-orm/pg-core';
 
 export const timestamps = {

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -1,4 +1,3 @@
-import 'server-only';
 import { pgEnum, pgTable as table } from 'drizzle-orm/pg-core';
 import * as t from 'drizzle-orm/pg-core';
 import { relations, sql } from 'drizzle-orm';


### PR DESCRIPTION
As it turns out, adding 'server-only' to files that don't actually need or care about it, breaks stuff. In this case, adding it to schema and helper files that drizzle-kit was trying to read was breaking it. There's nothing sensitive in these files, nor would they ever be included in our client-side package to begin with, so we should exclude the directive.